### PR TITLE
Add support for single-quoted and numeric keys

### DIFF
--- a/TOML-example.toml
+++ b/TOML-example.toml
@@ -103,12 +103,17 @@ a=[ 1, 2.0 ] # note: this is NOT ok
 [[Array.of.table]]
 
 [table]
-
-[table]
 key = "value"
 bare_key = "value"
 bare-key = "value"
+1234 = "value"
 
 "127.0.0.1" = "value"
 "character encoding" = "value"
 "ʎǝʞ" = "value"
+'key2' = "value"
+'quoted "value"' = "value"
+
+= "no key name"  # INVALID
+"" = "blank"     # VALID but discouraged
+'' = 'blank'     # VALID but discouraged

--- a/TOML.YAML-tmLanguage
+++ b/TOML.YAML-tmLanguage
@@ -20,7 +20,7 @@ repository:
       '1': {name: comment.line.number-sign.toml}
       '2': {name: punctuation.definition.comment.toml}
     comment: Comments
-  
+
   tables:
     patterns:
     - name: invalid.illegal.table.array.toml
@@ -56,7 +56,7 @@ repository:
       - include: '#comments'
       - include: '#keys'
       - include: '#illegal'
-      
+
   keys:
     patterns:
     - name: invalid.illegal.noKeyDefined.toml
@@ -65,7 +65,7 @@ repository:
     - name: invalid.deprecated.noValueGiven.toml
       match: (\s*[A-Za-z_\-][A-Za-z0-9_\-]*\s*=)(?=\s*$)
       comment: Assignments without value are unusual
-    - begin: '\s*([A-Za-z_-][A-Za-z0-9_-]*|".+")\s*(=)\s*'
+    - begin: \s*([A-Za-z_-][A-Za-z0-9_-]*|".+"|'.+'|[0-9]+)\s*(=)\s*
       end: ($|(?==)|\,|\s*\})
       beginCaptures:
         '1': {name: keyword.key.toml}

--- a/TOML.tmLanguage
+++ b/TOML.tmLanguage
@@ -253,7 +253,7 @@
 				</dict>
 				<dict>
 					<key>begin</key>
-					<string>\s*([A-Za-z_-][A-Za-z0-9_-]*|".+")\s*(=)\s*</string>
+					<string>\s*([A-Za-z_-][A-Za-z0-9_-]*|".+"|'.+'|[0-9]+)\s*(=)\s*</string>
 					<key>beginCaptures</key>
 					<dict>
 						<key>1</key>


### PR DESCRIPTION
This pull request adds support for single-quoted and numeric keys:

``` toml
[table]
key = "value"
bare_key = "value"
bare-key = "value"
1234 = "value"

"127.0.0.1" = "value"
"character encoding" = "value"
"ʎǝʞ" = "value"
'key2' = "value"
'quoted "value"' = "value"
```
