### PR TITLE
Fix parsing of inline table.

### DIFF
--- a/TOML-example.toml
+++ b/TOML-example.toml
@@ -108,6 +108,10 @@ bare_key = "value"
 bare-key = "value"
 1234 = "value"
 
+[inline_tables]
+table1 = { key = "value" }
+table2 = { key1 = "value1", key2 = "value2" }
+
 "127.0.0.1" = "value"
 "character encoding" = "value"
 "ʎǝʞ" = "value"

--- a/TOML.YAML-tmLanguage
+++ b/TOML.YAML-tmLanguage
@@ -66,7 +66,7 @@ repository:
       match: (\s*[A-Za-z_\-][A-Za-z0-9_\-]*\s*=)(?=\s*$)
       comment: Assignments without value are unusual
     - begin: \s*([A-Za-z_-][A-Za-z0-9_-]*|".+"|'.+'|[0-9]+)\s*(=)\s*
-      end: ($|(?==)|\,|\s*\})
+      end: ($|(?==)|\,|\s*(?=\}))
       beginCaptures:
         '1': {name: keyword.key.toml}
         '2': {name: punctuation.definition.keyValuePair.toml}

--- a/TOML.tmLanguage
+++ b/TOML.tmLanguage
@@ -268,7 +268,7 @@
 						</dict>
 					</dict>
 					<key>end</key>
-					<string>($|(?==)|\,|\s*\})</string>
+					<string>($|(?==)|\,|\s*(?=\}))</string>
 					<key>patterns</key>
 					<array>
 						<dict>


### PR DESCRIPTION
Parsing will now correctly terminate each inline table. Previously,
keys which had an inline table as a value (ex.
`table = { key = "value" }`) never actually ended and considered
the entire remainder of the document as part of the table, screwing
up comments.

Also adds an inline table to `TOML-example.toml`.

[Before](https://drive.google.com/file/d/0B4dgKrHZ1Fs0ekZtUVdXY2VsTlE/view?usp=sharing) -> [After](https://drive.google.com/file/d/0B4dgKrHZ1Fs0cl9UX3hYWWpUQzA/view?usp=sharing)
