### PR TITLE
Match filename 'poetry.lock'

### DIFF
--- a/TOML.sublime-syntax
+++ b/TOML.sublime-syntax
@@ -9,6 +9,7 @@ file_extensions:
   - Cargo.lock
   - Gopkg.lock
   - Pipfile
+  - poetry.lock
 
 scope: source.toml
 


### PR DESCRIPTION
This is the lock file used by the [Poetry](https://python-poetry.org/) dependency manager, which is increasingly becoming a standard

Example: [poetry.lock](https://github.com/python-poetry/poetry/blob/master/poetry.lock)