### PR TITLE
Highlight pdm.lock as TOML

### DIFF
--- a/TOML.sublime-syntax
+++ b/TOML.sublime-syntax
@@ -9,6 +9,7 @@ file_extensions:
   - Cargo.lock
   - Gopkg.lock
   - Pipfile
+  - pdm.lock
   - poetry.lock
 
 scope: source.toml


### PR DESCRIPTION
PDM (https://github.com/pdm-project/pdm) is a Python package/venv manager whose lock file is "pdm.lock".