### PR TITLE
Detect illegal end of inline table and pop early

### DIFF
--- a/TOML.sublime-syntax
+++ b/TOML.sublime-syntax
@@ -274,6 +274,9 @@ contexts:
       scope: punctuation.separator.inline-table.toml
       set:
         - match: '{{ws}}'
+        - match: '\}'
+          scope: invalid.illegal.table-end.toml
+          pop: true
         - match: ''
           set: [inline-keyval-sep, key]
     - match: '(?=\w+|.)'

--- a/syntax_test_toml.toml
+++ b/syntax_test_toml.toml
@@ -892,19 +892,35 @@ t = {b=true, i=1, f=1.0, dt=1979-05-27T07:32:00Z, s1='s', s2="s", s3='''s''', s4
 t = {,}
 #    ^^ invalid.illegal
 t = {=}
+#    ^ punctuation.definition.key-value
 #     ^ invalid.illegal
 t = {
-}  # comment to clear scope
+}
 #<- invalid.illegal
 t = {key=1,}
+#<- meta.tag.key entity.name.tag
+#         ^ punctuation.separator.inline-table
 #          ^ invalid.illegal
 t = {key}
+#    ^^^ meta.tag.key entity.name.tag
 #       ^ invalid.illegal
 t = {key=1 asdf}
 #          ^^^^^ invalid.illegal
 t = {key=1, asdf}
+#           ^^^^ meta.tag.key entity.name.tag
 #               ^ invalid.illegal
 t = {key=invalid}
+#       ^ punctuation.definition.key-value
 #        ^^^^^^^ invalid.illegal.value
+#               ^ punctuation.definition.inline-table.end
 t = {!=123}
 #    ^ invalid.illegal.key
+#     ^ punctuation.definition.key-value
+#      ^^^ constant.numeric.integer
+#         ^ punctuation.definition.inline-table.end
+t = {a=1, }
+#       ^ punctuation.separator.inline-table
+#         ^ invalid.illegal.table-end
+[test] # Verify that the illegal scope has popped
+#^^^^ meta.tag.table.toml entity.name.table.toml
+#    ^ punctuation.definition.table.end.toml


### PR DESCRIPTION
This fixes a problem where typing a comma in an inline table ends up highlighting the next line as an error.

I'm not sure if this is really the best solution, but seems to work for the common case.

Fixes #22