### PR TITLE
Highlight uv.lock as TOML

### DIFF
--- a/TOML.sublime-syntax
+++ b/TOML.sublime-syntax
@@ -11,6 +11,7 @@ file_extensions:
   - Pipfile
   - pdm.lock
   - poetry.lock
+  - uv.lock
 
 scope: source.toml
 


### PR DESCRIPTION
[uv](https://docs.astral.sh/uv/) is a package manager for Python and it uses TOML for its lock file format ([GitHub Linguist](https://github.com/github-linguist/linguist/blob/ebbedf06dc18e929104a4a3573ac43b43298a761/lib/linguist/languages.yml#L7166)).